### PR TITLE
Improve testing class namespaces

### DIFF
--- a/tests/Format/NonExistentFormatTest.php
+++ b/tests/Format/NonExistentFormatTest.php
@@ -16,7 +16,7 @@
 
 declare(strict_types=1);
 
-namespace Format;
+namespace OpenApiParams\Format;
 
 use OpenApiParams\Model\AbstractParamFormatTest;
 use OpenApiParams\Contract\ParamFormat;

--- a/tests/ParameeTest.php
+++ b/tests/ParameeTest.php
@@ -24,7 +24,7 @@ use OpenApiParams\ParamContext\ParamPathContext;
 use OpenApiParams\ParamContext\ParamQueryContext;
 use PHPUnit\Framework\TestCase;
 
-class OpenApiParamsTest extends TestCase
+class ParameeTest extends TestCase
 {
     /**
      * @dataProvider dataValuesProvider


### PR DESCRIPTION
# Changed log

- Adding the `OpenApiParams\Format` namespace for `tests/Format/NonExistentFormatTest.php` class.
- Letting the class name should be same as the `tests/ParameeTest.php` file name.